### PR TITLE
Add error handling to model caching

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -512,23 +512,33 @@ def get_model_flexible(model, content):
 
 def get_model_info(model):
     if not litellm._lazy_module:
+        # Initialize use_cache flag to control caching behavior
+        use_cache = True
         cache_dir = Path.home() / ".aider" / "caches"
         cache_file = cache_dir / "model_prices_and_context_window.json"
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Try to create cache directory with error handling
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as ex:
+            # If we can't create the cache directory, disable caching
+            use_cache = False
+            print(f"Warning: Unable to create cache directory: {ex}")
+        
+        if use_cache:
+            current_time = time.time()
+            cache_age = (
+                current_time - cache_file.stat().st_mtime if cache_file.exists() else float("inf")
+            )
 
-        current_time = time.time()
-        cache_age = (
-            current_time - cache_file.stat().st_mtime if cache_file.exists() else float("inf")
-        )
-
-        if cache_age < 60 * 60 * 24:
-            try:
-                content = json.loads(cache_file.read_text())
-                res = get_model_flexible(model, content)
-                if res:
-                    return res
-            except Exception as ex:
-                print(str(ex))
+            if cache_age < 60 * 60 * 24:
+                try:
+                    content = json.loads(cache_file.read_text())
+                    res = get_model_flexible(model, content)
+                    if res:
+                        return res
+                except Exception as ex:
+                    print(str(ex))
 
         import requests
 
@@ -536,7 +546,15 @@ def get_model_info(model):
             response = requests.get(model_info_url, timeout=5)
             if response.status_code == 200:
                 content = response.json()
-                cache_file.write_text(json.dumps(content, indent=4))
+                
+                # Try to write to cache with error handling
+                if use_cache:
+                    try:
+                        cache_file.write_text(json.dumps(content, indent=4))
+                    except OSError as ex:
+                        # If we can't write to cache, log the error but continue
+                        print(f"Warning: Unable to write to cache file: {ex}")
+                
                 res = get_model_flexible(model, content)
                 if res:
                     return res


### PR DESCRIPTION
Add `OSError` handling to `get_model_info` to gracefully manage cache directory creation and file writing failures, improving robustness against filesystem issues.

This ensures that if the cache directory cannot be created (e.g., due to permission issues), caching is entirely skipped. If writing to the cache file fails, an error is logged, but the function still returns the fetched model information, preventing a complete failure of the model lookup.

---
<a href="https://cursor.com/background-agent?bcId=bc-f91c7c3b-30c6-41a5-8603-cb2820306ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f91c7c3b-30c6-41a5-8603-cb2820306ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

